### PR TITLE
feat : Implement SavedRecipesScreen with RecipeCard UI and async data loading

### DIFF
--- a/lib/data/repository/mock_recipe_repository_impl.dart
+++ b/lib/data/repository/mock_recipe_repository_impl.dart
@@ -314,6 +314,8 @@ class MockRecipeRepositoryImpl implements RecipeRepository {
 
   @override
   Future<List<Recipe>> getRecipes() async {
+    await Future.delayed(const Duration(microseconds: 500));
+
     final recipes = _mockData['recipes']!;
     return recipes.map((e) => Recipe.fromJson(e)).toList();
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_recipe/data/repository/mock_bookmark_repository_impl.dart';
+import 'package:flutter_recipe/data/repository/mock_recipe_repository_impl.dart';
+import 'package:flutter_recipe/domain/model/recipe.dart';
+import 'package:flutter_recipe/domain/use_case/get_saved_recipes_use_case.dart';
 import 'package:flutter_recipe/presentation/components/big_button.dart';
 import 'package:flutter_recipe/presentation/components/filter_button.dart';
 import 'package:flutter_recipe/presentation/components/input_field.dart';
@@ -7,7 +11,7 @@ import 'package:flutter_recipe/presentation/components/rating_button.dart';
 import 'package:flutter_recipe/presentation/components/rating_dialog.dart';
 import 'package:flutter_recipe/presentation/components/small_button.dart';
 import 'package:flutter_recipe/presentation/components/tabs.dart';
-import 'package:flutter_recipe/presentation/sign_in/sign_in_screen.dart';
+import 'package:flutter_recipe/presentation/saved_recipes/saved_recipes_screen.dart';
 import 'package:flutter_recipe/ui/text_styles.dart';
 
 void main() {
@@ -21,11 +25,25 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'Flutter Demo',
-      theme: ThemeData(colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
+      theme: ThemeData(
+        colorScheme: const ColorScheme.light(),
         scaffoldBackgroundColor: Colors.white,
         useMaterial3: true,
       ),
-      home: const SignInScreen(),
+      home: FutureBuilder<List<Recipe>>(
+          future: GetSavedRecipesUseCase(
+            recipeRepository: MockRecipeRepositoryImpl(),
+            bookmarkRepository: MockBookmarkRepositoryImpl(),
+          ).execute(),
+          builder: (context, snapshot) {
+            if (snapshot.connectionState == ConnectionState.waiting) {
+              return const Center(child: CircularProgressIndicator());
+            }
+
+            final recipes = snapshot.data!;
+
+            return SavedRecipesScreen(recipes: recipes);
+          }),
     );
   }
 }

--- a/lib/presentation/components/recipe_card.dart
+++ b/lib/presentation/components/recipe_card.dart
@@ -1,0 +1,119 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_recipe/domain/model/recipe.dart';
+import 'package:flutter_recipe/ui/color_styles.dart';
+import 'package:flutter_recipe/ui/text_styles.dart';
+
+class RecipeCard extends StatelessWidget {
+  final Recipe recipe;
+
+  const RecipeCard({
+    super.key,
+    required this.recipe,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 10),
+      child: Stack(
+        children: [
+          AspectRatio(
+            aspectRatio: 315 / 150,
+            child: Container(
+              decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(10),
+                image: DecorationImage(
+                  image: NetworkImage(recipe.image),
+                  fit: BoxFit.cover,
+                ),
+              ),
+            ),
+          ),
+          Positioned(
+            bottom: 10,
+            left: 10,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                SizedBox(
+                  width: 200,
+                  child: Text(
+                    recipe.name,
+                    maxLines: 2,
+                    style: TextStyles.smallTextBold.copyWith(
+                      color: Colors.white,
+                    ),
+                  ),
+                ),
+                Text(
+                  'By ${recipe.chef}',
+                  style: TextStyles.smallerTextRegular.copyWith(
+                    color: Colors.white,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          Positioned(
+            right: 10,
+            bottom: 10,
+            child: Row(
+              children: [
+                const Icon(
+                  Icons.alarm,
+                  color: Colors.white,
+                  size: 17,
+                ),
+                const SizedBox(width: 5),
+                Text(
+                  recipe.time,
+                  style: TextStyles.smallerTextRegular.copyWith(
+                    color: Colors.white,
+                  ),
+                ),
+                const SizedBox(width: 10),
+                ClipOval(
+                  child: Container(
+                    color: Colors.white,
+                    padding: const EdgeInsets.all(3),
+                    child: const Icon(
+                      Icons.bookmark_border_outlined,
+                      color: ColorStyles.primary80,
+                      size: 16,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          Positioned(
+            top: 10,
+            right: 10,
+            child: Container(
+              width: 37,
+              height: 16,
+              decoration: BoxDecoration(
+                color: ColorStyles.secondary20,
+                borderRadius: BorderRadius.circular(20),
+              ),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  const Icon(
+                    Icons.star,
+                    size: 12,
+                    color: ColorStyles.rating,
+                  ),
+                  Text(
+                    recipe.rating.toString(),
+                    style: TextStyles.smallerTextRegular,
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/presentation/saved_recipes/saved_recipes_screen.dart
+++ b/lib/presentation/saved_recipes/saved_recipes_screen.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_recipe/domain/model/recipe.dart';
+import 'package:flutter_recipe/presentation/components/recipe_card.dart';
+import 'package:flutter_recipe/ui/text_styles.dart';
+
+class SavedRecipesScreen extends StatelessWidget {
+  final List<Recipe> recipes;
+
+  const SavedRecipesScreen({
+    super.key,
+    required this.recipes,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text(
+          'Saved recipes',
+          style: TextStyles.mediumTextBold,
+        ),
+        centerTitle: true,
+      ),
+      body: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 30),
+        child: ListView.builder(
+          itemCount: recipes.length,
+          itemBuilder: (context, index) {
+            return RecipeCard(recipe: recipes[index]);
+          },
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
**1. SavedRecipesScreen**

- `ListView.builder`를 사용하여 성능 최적화:
    - `recipes` 데이터를 담은 `RecipeCard` 위젯을 리스트 아이템으로 리턴
    - 효율적인 리스트 렌더링을 위해 `ListView.builder` 사용

**2. Main**

- 앱의 홈 화면으로 `SavedRecipesScreen` 사용:
    - `SavedRecipesScreen`에 `GetSavedRecipesUseCase`를 활용하여 `recipes` 데이터를 전달
    - `FutureBuilder<List<Recipe>>`를 사용하여 데이터를 비동기로 받아오고
    - 데이터가 로드되면 `SavedRecipesScreen`에 전달하여 화면에 렌더링

**3. RecipeCard**

- `RecipeCard`는 `Recipe` 모델을 받아서 해당 정보를 표시:
    - `Stack`과 `Positioned`를 활용해 다양한 UI 요소를 원하는 위치에 배치
    - `AspectRatio`를 사용하여 이미지 비율 유지
    - `EdgeInsets.symmetric(vertical: 10)`을 이용해 상하 여백 추가

**4. 데이터 지연 처리**

- `MockRecipeRepositoryImpl`에서 데이터 로딩에 딜레이 추가:
    - `getRecipes` 메서드에서 `Future.delayed`를 사용하여 0.5초 지연 처리. 실제 앱에서 데이터 로딩 지연처럼 보이게 처리하여 데이터 반환