### PR TITLE
feat: Integrate GoRouter for navigation and route management(Closes #44)

### DIFF
--- a/lib/core/routing/route_paths.dart
+++ b/lib/core/routing/route_paths.dart
@@ -1,0 +1,6 @@
+abstract class RoutePaths {
+  static const String splash = '/Splash';
+  static const String signIn = '/SingIn';
+  static const String signUp = '/SingUp';
+  static const String savedRecipes = '/SavedRecipes';
+}

--- a/lib/core/routing/router.dart
+++ b/lib/core/routing/router.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_recipe/core/routing/route_paths.dart';
+import 'package:flutter_recipe/data/repository/mock_bookmark_repository_impl.dart';
+import 'package:flutter_recipe/data/repository/mock_recipe_repository_impl.dart';
+import 'package:flutter_recipe/domain/model/recipe.dart';
+import 'package:flutter_recipe/domain/use_case/get_saved_recipes_use_case.dart';
+import 'package:flutter_recipe/presentation/saved_recipes/saved_recipes_screen.dart';
+import 'package:flutter_recipe/presentation/sign_in/sign_in_screen.dart';
+import 'package:flutter_recipe/presentation/sign_up/sign_up_screen.dart';
+import 'package:flutter_recipe/presentation/splash/splash_screen.dart';
+import 'package:go_router/go_router.dart';
+
+
+// GoRouter configuration
+final router = GoRouter(
+  initialLocation: RoutePaths.splash,
+  routes: [
+    GoRoute(
+      path: RoutePaths.signUp,
+      builder: (context, state) => SignUpScreen(
+        onTapSignIn: () => context.go(RoutePaths.signIn),
+      ),
+    ),
+    GoRoute(
+      path: RoutePaths.splash,
+      builder: (context, state) => SplashScreen(
+        onTapStartCooking: () => context.go(RoutePaths.signIn),
+      ),
+    ),
+    GoRoute(
+      path: RoutePaths.signIn,
+      builder: (context, state) => SignInScreen(
+        onTapSignUp: () => context.go(RoutePaths.signUp),
+        onTapSignIn: () => context.go(RoutePaths.savedRecipes),
+      ),
+    ),
+    GoRoute(
+      path: RoutePaths.savedRecipes,
+      builder: (context, state) => FutureBuilder<List<Recipe>>(
+        future: GetSavedRecipesUseCase(
+          recipeRepository: MockRecipeRepositoryImpl(),
+          bookmarkRepository: MockBookmarkRepositoryImpl(),
+        ).execute(),
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          }
+
+          final recipes = snapshot.data!;
+
+          return SavedRecipesScreen(recipes: recipes);
+        },
+      ),
+    ),
+  ],
+);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_recipe/core/routing/router.dart';
 import 'package:flutter_recipe/presentation/components/big_button.dart';
 import 'package:flutter_recipe/presentation/components/filter_button.dart';
 import 'package:flutter_recipe/presentation/components/input_field.dart';
@@ -20,14 +21,14 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
+    return MaterialApp.router(
+      routerConfig: router,
       title: 'Flutter Demo',
       theme: ThemeData(
         colorScheme: const ColorScheme.light(),
         scaffoldBackgroundColor: Colors.white,
         useMaterial3: true,
       ),
-      home: SplashScreen(onTapStartCooking: () {  },),
     );
   }
 }

--- a/lib/presentation/sign_in/sign_in_screen.dart
+++ b/lib/presentation/sign_in/sign_in_screen.dart
@@ -5,7 +5,14 @@ import 'package:flutter_recipe/ui/color_styles.dart';
 import 'package:flutter_recipe/ui/text_styles.dart';
 
 class SignInScreen extends StatelessWidget {
-  const SignInScreen({super.key});
+  final void Function() onTapSignIn;
+  final void Function() onTapSignUp;
+
+  const SignInScreen({
+    super.key,
+    required this.onTapSignUp,
+    required this.onTapSignIn,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -45,7 +52,7 @@ class SignInScreen extends StatelessWidget {
               const SizedBox(height: 25),
               BigButton(
                 'Sign In',
-                onPressed: () {},
+                onPressed: onTapSignIn,
               ),
               const SizedBox(height: 20),
               Row(
@@ -96,10 +103,13 @@ class SignInScreen extends StatelessWidget {
                     'Don’t have an account? ',
                     style: TextStyles.smallerTextBold,
                   ),
-                  Text(
-                    'Sign up',
-                    style: TextStyles.smallerTextBold.copyWith(
-                      color: ColorStyles.secondary100,
+                  GestureDetector(
+                    onTap: onTapSignUp,
+                    child: Text(
+                      'Sign up',
+                      style: TextStyles.smallerTextBold.copyWith(
+                        color: ColorStyles.secondary100,
+                      ),
                     ),
                   ),
                 ],

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -75,6 +75,19 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_web_plugins:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  go_router:
+    dependency: "direct main"
+    description:
+      name: go_router
+      sha256: "04539267a740931c6d4479a10d466717ca5901c6fdfd3fcda09391bbb8ebd651"
+      url: "https://pub.dev"
+    source: hosted
+    version: "14.8.0"
   leak_tracker:
     dependency: transitive
     description:
@@ -107,6 +120,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.1.1"
+  logging:
+    dependency: transitive
+    description:
+      name: logging
+      sha256: c8245ada5f1717ed44271ed1c26b8ce85ca3228fd2ffdb75468ab01979309d61
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.0"
   matcher:
     dependency: transitive
     description:
@@ -210,4 +231,4 @@ packages:
     version: "14.3.0"
 sdks:
   dart: ">=3.6.2 <4.0.0"
-  flutter: ">=3.18.0-18.0.pre.54"
+  flutter: ">=3.22.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
+  go_router: ^14.8.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
### 스택에 쌓이지 않고 replace되도록 화면 이동
#### 1. GoRouter 설정: 
- RoutePaths에 경로들을 정의하여 앱 내에서 사용할 라우트를 설정.

#### 2. 각 화면에 대한 GoRoute 설정:
- context.go로 리플레이스 처리
- `GoRouter`의 `GoRoute`를 사용하여 화면을 라우팅하도록 구성.
- 각 경로에 대해 적절한 화면을 구성하며, 각 화면에서 다른 화면으로의 이동이 가능하도록 콜백 함수(onTapSignIn, onTapSignUp, onTapStartCooking) 정의
    - **SplashScreen**: 'Start Cooking' 버튼을 누르면 SignIn 화면으로 이동.
    - **SignInScreen**: 로그인 후 SavedRecipes 화면으로 이동.
    - **SignUpScreen**: 회원가입 후 SignIn 화면으로 이동.
    - **SavedRecipesScreen**: 저장된 레시피를 표시하며 `FutureBuilder`를 사용하여 비동기 데이터 로딩.
    
#### 3. Main.dart 수정:
- MaterialApp.router를 사용하여 GoRouter를 라우팅 시스템으로 설정. 
- routerConfig를 사용해 GoRouter를 앱의 주요 라우팅 시스템으로 통합.