### PR TITLE
feat: implement home to search navigation (Closes #58)

### DIFF
--- a/lib/core/routing/route_paths.dart
+++ b/lib/core/routing/route_paths.dart
@@ -8,5 +8,7 @@ abstract class RoutePaths {
   static const String notifications = '/Notifications';
   static const String profile = '/Profile';
 
+  static const String search = '/Home/Search';
+
   static const String test = '/Test';
 }

--- a/lib/core/routing/router.dart
+++ b/lib/core/routing/router.dart
@@ -1,10 +1,12 @@
 import 'package:flutter_recipe/core/routing/route_paths.dart';
 import 'package:flutter_recipe/main.dart';
-import 'package:flutter_recipe/presentation/home/home_screen.dart';
+import 'package:flutter_recipe/presentation/home/screen/home_root.dart';
+import 'package:flutter_recipe/presentation/home/screen/home_screen.dart';
 import 'package:flutter_recipe/presentation/main/main_screen.dart';
 import 'package:flutter_recipe/presentation/notifications/notifications_screen.dart';
 import 'package:flutter_recipe/presentation/profile/profile_screen.dart';
 import 'package:flutter_recipe/presentation/saved_recipes/screen/saved_recipes_root.dart';
+import 'package:flutter_recipe/presentation/search/screen/search_screen.dart';
 import 'package:flutter_recipe/presentation/sign_in/sign_in_screen.dart';
 import 'package:flutter_recipe/presentation/sign_up/sign_up_screen.dart';
 import 'package:flutter_recipe/presentation/splash/splash_screen.dart';
@@ -12,7 +14,6 @@ import 'package:go_router/go_router.dart';
 
 // GoRouter configuration
 final router = GoRouter(
-  //initialLocation: RoutePaths.test,
   initialLocation: RoutePaths.splash,
   routes: [
     GoRoute(
@@ -38,6 +39,10 @@ final router = GoRouter(
         onTapSignIn: () => context.go(RoutePaths.home),
       ),
     ),
+    GoRoute(
+      path: RoutePaths.search,
+      builder: (context, state) => const SearchScreen(),
+    ),
     StatefulShellRoute.indexedStack(
       builder: (context, state, navigationShell) {
         return MainScreen(
@@ -56,7 +61,7 @@ final router = GoRouter(
           routes: [
             GoRoute(
               path: RoutePaths.home,
-              builder: (context, state) => const HomeScreen(name: 'Jega'),
+              builder: (context, state) => const HomeRoot(),
             ),
           ],
         ),

--- a/lib/presentation/home/screen/home_root.dart
+++ b/lib/presentation/home/screen/home_root.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_recipe/core/routing/route_paths.dart';
+import 'package:flutter_recipe/presentation/home/screen/home_screen.dart';
+import 'package:go_router/go_router.dart';
+
+
+class HomeRoot extends StatelessWidget {
+  const HomeRoot({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return HomeScreen(
+      name: 'Jega',
+      onTapSearchField: () => context.push(RoutePaths.search),
+    );
+  }
+}

--- a/lib/presentation/home/screen/home_screen.dart
+++ b/lib/presentation/home/screen/home_screen.dart
@@ -5,10 +5,12 @@ import 'package:flutter_recipe/ui/text_styles.dart';
 
 class HomeScreen extends StatelessWidget {
   final String name;
+  final void Function() onTapSearchField;
 
   const HomeScreen({
     super.key,
     required this.name,
+    required this.onTapSearchField,
   });
 
   @override
@@ -52,10 +54,16 @@ class HomeScreen extends StatelessWidget {
             const SizedBox(height: 30),
             Row(
               children: [
-                const Expanded(
-                  child: SearchInputField(
-                    placeHolder: 'Search Recipe',
-                    isReadOnly: true,
+                Expanded(
+                  child: GestureDetector(
+                    behavior: HitTestBehavior.opaque,
+                    onTap: onTapSearchField,
+                    child: const IgnorePointer(
+                      child: SearchInputField(
+                        placeHolder: 'Search Recipe',
+                        isReadOnly: true,
+                      ),
+                    ),
                   ),
                 ),
                 const SizedBox(width: 20),


### PR DESCRIPTION
- Add HomeRoot for managing search navigation
- Add search route path and configuration
- Add GestureDetector to SearchInputField for navigation

This change enables navigation from HomeScreen to SearchScreen when the search field is tapped.