### PR TITLE
feat: SearchScreen 최근 검색 결과 저장 및 로드 구현 (Closes #61)

### DIFF
--- a/lib/core/routing/router.dart
+++ b/lib/core/routing/router.dart
@@ -1,12 +1,11 @@
 import 'package:flutter_recipe/core/routing/route_paths.dart';
 import 'package:flutter_recipe/main.dart';
 import 'package:flutter_recipe/presentation/home/screen/home_root.dart';
-import 'package:flutter_recipe/presentation/home/screen/home_screen.dart';
 import 'package:flutter_recipe/presentation/main/main_screen.dart';
 import 'package:flutter_recipe/presentation/notifications/notifications_screen.dart';
 import 'package:flutter_recipe/presentation/profile/profile_screen.dart';
 import 'package:flutter_recipe/presentation/saved_recipes/screen/saved_recipes_root.dart';
-import 'package:flutter_recipe/presentation/search/screen/search_screen.dart';
+import 'package:flutter_recipe/presentation/search/screen/search_root.dart';
 import 'package:flutter_recipe/presentation/sign_in/sign_in_screen.dart';
 import 'package:flutter_recipe/presentation/sign_up/sign_up_screen.dart';
 import 'package:flutter_recipe/presentation/splash/splash_screen.dart';
@@ -41,7 +40,7 @@ final router = GoRouter(
     ),
     GoRoute(
       path: RoutePaths.search,
-      builder: (context, state) => const SearchScreen(),
+      builder: (context, state) => const SearchRoot(),
     ),
     StatefulShellRoute.indexedStack(
       builder: (context, state, navigationShell) {

--- a/lib/data/data_source/search_data_source_impl.dart
+++ b/lib/data/data_source/search_data_source_impl.dart
@@ -1,27 +1,21 @@
-import 'dart:convert';
 import 'package:flutter_recipe/data/data_source/search_data_source.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 
 class SearchDataSourceImpl implements SearchDataSource {
-  static const String _recentSearchKey = 'recent_searches';
-  final SharedPreferences _prefs;
-
-  SearchDataSourceImpl({
-    required SharedPreferences prefs,
-  }) : _prefs = prefs;
+  // 메모리 상에 저장된 최근 검색 리스트
+  final List<Map<String, dynamic>> _recentSearches = [];
 
   @override
   Future<List<Map<String, dynamic>>> getRecentSearches() async {
-    final jsonString = _prefs.getString(_recentSearchKey);
-    if (jsonString == null) return [];
-
-    final List<dynamic> jsonList = jsonDecode(jsonString);
-    return jsonList.cast<Map<String, dynamic>>();
+    // 최근 검색 결과를 반환
+    return _recentSearches;
   }
 
   @override
   Future<void> saveRecentSearches(List<Map<String, dynamic>> recipes) async {
-    final jsonString = jsonEncode(recipes);
-    await _prefs.setString(_recentSearchKey, jsonString);
+    // 새로운 검색 결과를 저장
+    print('Saving recent searches: ${recipes.length} items');
+    _recentSearches
+      ..clear() // 이전 검색결과를 지우고
+      ..addAll(recipes); // 새로운 검색결과를 추가
   }
 }

--- a/lib/domain/use_case/search_recipes_use_case.dart
+++ b/lib/domain/use_case/search_recipes_use_case.dart
@@ -1,0 +1,30 @@
+import 'package:flutter_recipe/domain/model/recipe.dart';
+import 'package:flutter_recipe/domain/repository/recent_search_recipe_repository.dart';
+import 'package:flutter_recipe/domain/repository/recipe_repository.dart';
+
+class SearchRecipesUseCase {
+  final RecipeRepository _recipeRepository;
+  final RecentSearchRecipeRepository _recentSearchRecipeRepository;
+
+  const SearchRecipesUseCase({
+    required RecipeRepository recipeRepository,
+    required RecentSearchRecipeRepository recentSearchRecipeRepository,
+  })  : _recipeRepository = recipeRepository,
+        _recentSearchRecipeRepository = recentSearchRecipeRepository;
+
+  Future<List<Recipe>> execute(String query) async {
+    if (query.isEmpty) {
+      return [];
+    }
+
+    final results = (await _recipeRepository.getRecipes())
+        .where((e) => e.name.toLowerCase().contains(query.toLowerCase()))
+        .toList();
+
+    // 최근 검색 결과를 메모리에 저장
+    //print('Updating recent search recipes: ${results.length} items');
+    await _recentSearchRecipeRepository.updateRecentSearchRecipes(results);
+
+    return results;
+  }
+}

--- a/lib/presentation/components/search_input_field.dart
+++ b/lib/presentation/components/search_input_field.dart
@@ -6,12 +6,14 @@ class SearchInputField extends StatelessWidget {
   final String placeHolder;
   final TextEditingController? controller;
   final bool isReadOnly;
+  final void Function(String query)? onChanged;
 
   const SearchInputField({
     super.key,
     required this.placeHolder,
     this.controller,
     this.isReadOnly = false,
+    this.onChanged,
   });
 
   @override
@@ -21,6 +23,7 @@ class SearchInputField extends StatelessWidget {
       child: TextField(
         readOnly: isReadOnly,
         controller: controller,
+        onChanged: onChanged,
         decoration: InputDecoration(
           prefixIcon: const Icon(
             Icons.search,

--- a/lib/presentation/search/screen/search_root.dart
+++ b/lib/presentation/search/screen/search_root.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_recipe/data/data_source/recipe_data_source_impl.dart';
+import 'package:flutter_recipe/data/data_source/search_data_source_impl.dart';
+import 'package:flutter_recipe/data/repository/mock_recipe_repository_impl.dart';
+import 'package:flutter_recipe/data/repository/recent_search_recipe_repository_impl.dart';
+import 'package:flutter_recipe/domain/use_case/search_recipes_use_case.dart';
+import 'package:flutter_recipe/presentation/search/screen/search_screen.dart';
+import 'package:flutter_recipe/presentation/search/search_view_model.dart';
+
+final _recentSearchRecipeRepository =
+    RecentSearchRecipeRepositoryImpl(searchDataSource: SearchDataSourceImpl());
+
+class SearchRoot extends StatelessWidget {
+  const SearchRoot({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final viewModel = SearchViewModel(
+      recentSearchRecipeRepository: _recentSearchRecipeRepository,
+      searchRecipesUseCase: SearchRecipesUseCase(
+        recipeRepository: MockRecipeRepositoryImpl(
+          recipeDataSource: RecipeDataSourceImpl(),
+        ),
+        recentSearchRecipeRepository: RecentSearchRecipeRepositoryImpl(
+            searchDataSource: SearchDataSourceImpl()),
+      ),
+    );
+
+    return ListenableBuilder(
+      listenable: viewModel,
+      builder: (context, widget) {
+        return SearchScreen(
+          state: viewModel.state,
+          onChanged: viewModel.searchRecipes,
+        );
+      },
+    );
+  }
+}

--- a/lib/presentation/search/screen/search_screen.dart
+++ b/lib/presentation/search/screen/search_screen.dart
@@ -1,41 +1,20 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_recipe/presentation/components/recipe_grid_item.dart';
 import 'package:flutter_recipe/presentation/components/search_input_field.dart';
+import 'package:flutter_recipe/presentation/search/search_state.dart';
 import 'package:flutter_recipe/ui/color_styles.dart';
 import 'package:flutter_recipe/ui/text_styles.dart';
-import 'package:flutter_recipe/domain/model/recipe.dart';
 
 class SearchScreen extends StatelessWidget {
-  const SearchScreen({super.key});
+  final SearchState state;
+
+  const SearchScreen({
+    super.key,
+    required this.state,
+  });
 
   @override
   Widget build(BuildContext context) {
-    // 임시 데이터
-    final dummyRecipes = [
-      Recipe(
-        category: "Indian",
-        id: 1,
-        name: "Traditional spare ribs baked",
-        image: "https://cdn.pixabay.com/photo/2017/11/10/15/04/steak-2936531_1280.jpg",
-        chef: "Chef John",
-        time: "20 min",
-        rating: 4.0,
-        ingredients: const [],
-      ),
-      Recipe(
-        category: "Asian",
-        id: 2,
-        name: "Spice roasted chicken",
-        image: "https://cdn.pixabay.com/photo/2018/12/04/16/49/tandoori-3856045_1280.jpg",
-        chef: "Mark Kelvin",
-        time: "20 min",
-        rating: 4.0,
-        ingredients: const [],
-      ),
-    ];
-
-    final isLoading = false; // 임시 로딩 상태
-
     return Scaffold(
       appBar: AppBar(
         title: const Text(
@@ -77,18 +56,19 @@ class SearchScreen extends StatelessWidget {
             ),
             const SizedBox(height: 20),
             Expanded(
-              child: isLoading
+              child: state.isLoading
                   ? const Center(
                 child: CircularProgressIndicator(),
               )
                   : GridView.builder(
-                gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                gridDelegate:
+                const SliverGridDelegateWithFixedCrossAxisCount(
                   crossAxisCount: 2,
                   crossAxisSpacing: 15,
                 ),
-                itemCount: dummyRecipes.length,
+                itemCount: state.recipes.length,
                 itemBuilder: (context, index) {
-                  final recipe = dummyRecipes[index];
+                  final recipe = state.recipes[index];
                   return RecipeGridItem(recipe: recipe);
                 },
               ),

--- a/lib/presentation/search/screen/search_screen.dart
+++ b/lib/presentation/search/screen/search_screen.dart
@@ -7,10 +7,12 @@ import 'package:flutter_recipe/ui/text_styles.dart';
 
 class SearchScreen extends StatelessWidget {
   final SearchState state;
+  final void Function(String query)? onChanged;
 
   const SearchScreen({
     super.key,
     required this.state,
+    this.onChanged,
   });
 
   @override
@@ -31,8 +33,11 @@ class SearchScreen extends StatelessWidget {
             const SizedBox(height: 17),
             Row(
               children: [
-                const Expanded(
-                  child: SearchInputField(placeHolder: 'Search Recipe'),
+                Expanded(
+                  child: SearchInputField(
+                    placeHolder: 'Search Recipe',
+                    onChanged: onChanged,
+                  ),
                 ),
                 const SizedBox(width: 20),
                 Container(
@@ -58,20 +63,20 @@ class SearchScreen extends StatelessWidget {
             Expanded(
               child: state.isLoading
                   ? const Center(
-                child: CircularProgressIndicator(),
-              )
+                      child: CircularProgressIndicator(),
+                    )
                   : GridView.builder(
-                gridDelegate:
-                const SliverGridDelegateWithFixedCrossAxisCount(
-                  crossAxisCount: 2,
-                  crossAxisSpacing: 15,
-                ),
-                itemCount: state.recipes.length,
-                itemBuilder: (context, index) {
-                  final recipe = state.recipes[index];
-                  return RecipeGridItem(recipe: recipe);
-                },
-              ),
+                      gridDelegate:
+                          const SliverGridDelegateWithFixedCrossAxisCount(
+                        crossAxisCount: 2,
+                        crossAxisSpacing: 15,
+                      ),
+                      itemCount: state.recipes.length,
+                      itemBuilder: (context, index) {
+                        final recipe = state.recipes[index];
+                        return RecipeGridItem(recipe: recipe);
+                      },
+                    ),
             )
           ],
         ),

--- a/lib/presentation/search/search_view_model.dart
+++ b/lib/presentation/search/search_view_model.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_recipe/domain/repository/recent_search_recipe_repository.dart';
+import 'package:flutter_recipe/domain/use_case/search_recipes_use_case.dart';
+import 'package:flutter_recipe/presentation/search/search_state.dart';
+
+class SearchViewModel with ChangeNotifier {
+  final RecentSearchRecipeRepository _recentSearchRecipeRepository;
+  final SearchRecipesUseCase _searchRecipesUseCase;
+
+  SearchViewModel({
+    required RecentSearchRecipeRepository recentSearchRecipeRepository,
+    required SearchRecipesUseCase searchRecipesUseCase,
+  })  : _recentSearchRecipeRepository = recentSearchRecipeRepository,
+        _searchRecipesUseCase = searchRecipesUseCase {
+    _loadRecentSearchRecipes();
+  }
+
+  SearchState _state = const SearchState();
+
+  SearchState get state => _state;
+
+  // 최근 검색 결과 로드
+  void _loadRecentSearchRecipes() async {
+    _state = state.copyWith(isLoading: true);
+    notifyListeners();
+
+    final recentSearches =
+        await _recentSearchRecipeRepository.getRecentSearchRecipes();
+
+    //print('Loaded recent searches: ${recentSearches.length} items');
+
+    _state = state.copyWith(
+      recipes: recentSearches,
+      isLoading: false,
+    );
+    notifyListeners();
+  }
+
+  // 검색 메서드
+  void searchRecipes(String query) async {
+    _state = state.copyWith(isLoading: true);
+    notifyListeners();
+
+    final results = await _searchRecipesUseCase.execute(query);
+
+    _state = state.copyWith(
+      recipes: results,
+      isLoading: false,
+    );
+    notifyListeners();
+  }
+}


### PR DESCRIPTION
**1. Search Input Field 수정**
- 변경 사항: 사용자가 입력한 검색 쿼리를 콜백을 통해 전달하도록 수정.
- 작업 내용: search input field에서 사용자 입력을 받아 final void Function(String query)? onChanged 콜백으로 부모 컴포넌트로 넘기도록 구현.

**2. Search Screen 수정**
- 변경 사항:
화면에서 로딩 로직 제거.
더미 데이터 제거.
searchInputField에서 받아온 검색 쿼리를 콜백을 통해 search_root로 넘기도록 구현.
- 작업 내용:
SearchScreen에서 로딩 로직을 없애고, 실제 API 호출에 의한 동작만 처리하도록 변경.
더 이상 사용되지 않는 더미 데이터를 제거하고, searchInputField에서 받은 검색 쿼리를 onChanged 콜백을 통해 search_root로 전달.

**3. Search Root 새로 구현**
- 변경 사항: SearchRoot 화면을 새로 구현하고, 라우터에서 SearchScreen을 SearchRoot로 변경.
- 작업 내용: search_screen.dart 대신 search_root.dart를 사용하도록 라우터를 수정하고, 새로운 search_root 컴포넌트를 구현.

**4. Search ViewModel 새로 구현**
- 변경 사항: SearchViewModel을 새로 구현하여, 검색 관련 로직을 뷰모델로 분리.
- 작업 내용: 검색 상태와 관련된 로직을 SearchViewModel에서 관리하도록 구현하고, 뷰는 상태만 구독하도록 변경.

**5. Search Recipes Use Case 새로 구현**
- 변경 사항: search_recipes_use_case를 새로 구현하여, 검색 로직을 캡슐화.
- 작업 내용: SearchRecipesUseCase 클래스를 새로 추가하여, 검색 관련 비즈니스 로직을 처리하도록 구현.

**6. Search Data Source 수정**
- 변경 사항: 이전에 shared reference 방식으로 처리하던 부분을 final 변수를 사용하여 검색 결과를 메모리에 저장하도록 수정.
- 작업 내용: SearchDataSourceImpl에서 recentSearches를 final List<Map<String, dynamic>> 타입으로 선언하고, 메모리에 저장된 최근 검색 리스트를 관리하도록 수정.