### PR TITLE
feat: getit di (Closes # 70)

### DIFF
--- a/lib/core/di/di_setup.dart
+++ b/lib/core/di/di_setup.dart
@@ -1,19 +1,34 @@
 import 'package:flutter_recipe/data/data_source/recipe_data_source.dart';
 import 'package:flutter_recipe/data/data_source/recipe_data_source_impl.dart';
+import 'package:flutter_recipe/data/data_source/search_data_source.dart';
+import 'package:flutter_recipe/data/data_source/search_data_source_impl.dart';
 import 'package:flutter_recipe/data/repository/mock_bookmark_repository_impl.dart';
 import 'package:flutter_recipe/data/repository/mock_recipe_repository_impl.dart';
+import 'package:flutter_recipe/data/repository/recent_search_recipe_repository_impl.dart';
 import 'package:flutter_recipe/domain/repository/bookmark_repository.dart';
+import 'package:flutter_recipe/domain/repository/recent_search_recipe_repository.dart';
 import 'package:flutter_recipe/domain/repository/recipe_repository.dart';
 import 'package:flutter_recipe/domain/use_case/get_saved_recipes_use_case.dart';
+import 'package:flutter_recipe/domain/use_case/search_recipes_use_case.dart';
 import 'package:flutter_recipe/presentation/saved_recipes/saved_recipes_view_model.dart';
+import 'package:flutter_recipe/presentation/search/search_view_model.dart';
 import 'package:get_it/get_it.dart';
 
 final getIt = GetIt.instance;
 
 void diSetup() {
   // data source, repository 인터페이스 구현체. 타입 명시해주기
+  getIt.registerSingleton<SearchDataSource>(
+    SearchDataSourceImpl(),
+  );
   getIt.registerSingleton<RecipeDataSource>(
     RecipeDataSourceImpl(),
+  );
+
+  getIt.registerSingleton<RecentSearchRecipeRepository>(
+    RecentSearchRecipeRepositoryImpl(
+      searchDataSource: getIt(),
+    ),
   );
   getIt.registerSingleton<RecipeRepository>(
     MockRecipeRepositoryImpl(
@@ -32,11 +47,25 @@ void diSetup() {
     ),
   );
 
+  getIt.registerSingleton(
+    SearchRecipesUseCase(
+      recipeRepository: getIt(),
+      recentSearchRecipeRepository: getIt(),
+    ),
+  );
+
   // ViewModel은 상태를 유지하거나 변경하는 객체이기 때문에 각 화면마다 별개의 인스턴스를 생성해야 하기에 Factory로
   // ViewModel을 요청할 때마다 새로운 인스턴스를 생성하고, ViewModel이 필요로 하는 의존성(UseCase)을 GetIt에서 가져와서 주입
   getIt.registerFactory<SavedRecipesViewModel>(
     () => SavedRecipesViewModel(
       getSavedRecipesUseCase: getIt(),
+    ),
+  );
+
+  getIt.registerFactory<SearchViewModel>(
+    () => SearchViewModel(
+      recentSearchRecipeRepository: getIt(),
+      searchRecipesUseCase: getIt(),
     ),
   );
 }

--- a/lib/core/di/di_setup.dart
+++ b/lib/core/di/di_setup.dart
@@ -1,0 +1,42 @@
+import 'package:flutter_recipe/data/data_source/recipe_data_source.dart';
+import 'package:flutter_recipe/data/data_source/recipe_data_source_impl.dart';
+import 'package:flutter_recipe/data/repository/mock_bookmark_repository_impl.dart';
+import 'package:flutter_recipe/data/repository/mock_recipe_repository_impl.dart';
+import 'package:flutter_recipe/domain/repository/bookmark_repository.dart';
+import 'package:flutter_recipe/domain/repository/recipe_repository.dart';
+import 'package:flutter_recipe/domain/use_case/get_saved_recipes_use_case.dart';
+import 'package:flutter_recipe/presentation/saved_recipes/saved_recipes_view_model.dart';
+import 'package:get_it/get_it.dart';
+
+final getIt = GetIt.instance;
+
+void diSetup() {
+  // data source, repository 인터페이스 구현체. 타입 명시해주기
+  getIt.registerSingleton<RecipeDataSource>(
+    RecipeDataSourceImpl(),
+  );
+  getIt.registerSingleton<RecipeRepository>(
+    MockRecipeRepositoryImpl(
+      recipeDataSource: getIt(),
+    ),
+  );
+  getIt.registerSingleton<BookmarkRepository>(
+    MockBookmarkRepositoryImpl(),
+  );
+
+  // usecase. 인터페이스 구현체 아니고 일반 클래스라서 타입 명시 필요 없음
+  getIt.registerSingleton(
+    GetSavedRecipesUseCase(
+      recipeRepository: getIt(),
+      bookmarkRepository: getIt(),
+    ),
+  );
+
+  // ViewModel은 상태를 유지하거나 변경하는 객체이기 때문에 각 화면마다 별개의 인스턴스를 생성해야 하기에 Factory로
+  // ViewModel을 요청할 때마다 새로운 인스턴스를 생성하고, ViewModel이 필요로 하는 의존성(UseCase)을 GetIt에서 가져와서 주입
+  getIt.registerFactory<SavedRecipesViewModel>(
+    () => SavedRecipesViewModel(
+      getSavedRecipesUseCase: getIt(),
+    ),
+  );
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_recipe/core/di/di_setup.dart';
 import 'package:flutter_recipe/core/routing/router.dart';
 import 'package:flutter_recipe/presentation/components/big_button.dart';
 import 'package:flutter_recipe/presentation/components/filter_button.dart';
@@ -12,6 +13,7 @@ import 'package:flutter_recipe/presentation/components/tabs.dart';
 import 'package:flutter_recipe/ui/text_styles.dart';
 
 void main() {
+  diSetup();
   runApp(const MyApp());
 }
 

--- a/lib/presentation/saved_recipes/screen/saved_recipes_root.dart
+++ b/lib/presentation/saved_recipes/screen/saved_recipes_root.dart
@@ -1,24 +1,14 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_recipe/data/data_source/recipe_data_source_impl.dart';
-import 'package:flutter_recipe/data/repository/mock_bookmark_repository_impl.dart';
-import 'package:flutter_recipe/data/repository/mock_recipe_repository_impl.dart';
-import 'package:flutter_recipe/domain/use_case/get_saved_recipes_use_case.dart';
+import 'package:flutter_recipe/core/di/di_setup.dart';
 import 'package:flutter_recipe/presentation/saved_recipes/saved_recipes_view_model.dart';
 import 'package:flutter_recipe/presentation/saved_recipes/screen/saved_recipes_screen.dart';
-
-final _getSavedRecipesUseCase = GetSavedRecipesUseCase( // 싱글턴(나중에 DI 통해 분리할거임)
-  recipeRepository: MockRecipeRepositoryImpl(recipeDataSource: RecipeDataSourceImpl()),
-  bookmarkRepository: MockBookmarkRepositoryImpl(),
-);
 
 class SavedRecipesRoot extends StatelessWidget {
   const SavedRecipesRoot({super.key});
 
   @override
   Widget build(BuildContext context) {
-    final viewModel = SavedRecipesViewModel(
-      getSavedRecipesUseCase: _getSavedRecipesUseCase,
-    );
+    final viewModel = getIt<SavedRecipesViewModel>(); // 호출할 때마다 새로운 인스턴스 받을 수 있음
 
     return ListenableBuilder(
       listenable: viewModel,

--- a/lib/presentation/search/screen/search_root.dart
+++ b/lib/presentation/search/screen/search_root.dart
@@ -1,30 +1,14 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_recipe/data/data_source/recipe_data_source_impl.dart';
-import 'package:flutter_recipe/data/data_source/search_data_source_impl.dart';
-import 'package:flutter_recipe/data/repository/mock_recipe_repository_impl.dart';
-import 'package:flutter_recipe/data/repository/recent_search_recipe_repository_impl.dart';
-import 'package:flutter_recipe/domain/use_case/search_recipes_use_case.dart';
+import 'package:flutter_recipe/core/di/di_setup.dart';
 import 'package:flutter_recipe/presentation/search/screen/search_screen.dart';
 import 'package:flutter_recipe/presentation/search/search_view_model.dart';
-
-final _recentSearchRecipeRepository =
-    RecentSearchRecipeRepositoryImpl(searchDataSource: SearchDataSourceImpl());
 
 class SearchRoot extends StatelessWidget {
   const SearchRoot({super.key});
 
   @override
   Widget build(BuildContext context) {
-    final viewModel = SearchViewModel(
-      recentSearchRecipeRepository: _recentSearchRecipeRepository,
-      searchRecipesUseCase: SearchRecipesUseCase(
-        recipeRepository: MockRecipeRepositoryImpl(
-          recipeDataSource: RecipeDataSourceImpl(),
-        ),
-        recentSearchRecipeRepository: RecentSearchRecipeRepositoryImpl(
-            searchDataSource: SearchDataSourceImpl()),
-      ),
-    );
+    final viewModel = getIt<SearchViewModel>();
 
     return ListenableBuilder(
       listenable: viewModel,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -256,6 +256,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.0"
+  get_it:
+    dependency: "direct main"
+    description:
+      name: get_it
+      sha256: f126a3e286b7f5b578bf436d5592968706c4c1de28a228b870ce375d9f743103
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.0.3"
   glob:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,6 +37,7 @@ dependencies:
   cupertino_icons: ^1.0.8
   go_router: ^14.8.0
   freezed_annotation: ^2.4.4
+  get_it: ^8.0.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
📝 변경 내용
- get_it 패키지 추가
- core/di/di_setup.dart 생성 및 DI 로직 구현
- SavedRecipesRoot, SearchRoot의 의존성 주입 방식 변경
- main.dart에 DI 초기화 추가

📋 PR Point
- 흩어져 있던 의존성 코드들을 중앙화
- ViewModel은 Factory로, Repository/UseCase는 Singleton으로 등록
- Root 컴포넌트에서는 getIt을 통해 ViewModel만 주입받도록 단순화