### PR TITLE
[FEAT/#74] Filter UI 구현 및 상태 관리

### DIFF
--- a/lib/presentation/components/filter_buttons.dart
+++ b/lib/presentation/components/filter_buttons.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+
+import 'filter_button.dart';
+
+class FilterButtons extends StatelessWidget {
+  final List<String> items;
+  final String selectedItem;
+  final void Function(String item) onSelected;
+
+  const FilterButtons({
+    super.key,
+    required this.items,
+    required this.selectedItem,
+    required this.onSelected,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Wrap(
+      children: items.expand((e) {
+        return [
+          GestureDetector(
+            onTap: () => onSelected(e),
+            child: FilterButton(e, isSelected: e == selectedItem),
+          ),
+          const SizedBox(width: 10),
+        ];
+      }).toList(),
+    );
+  }
+}

--- a/lib/presentation/components/search_filter_sheet.dart
+++ b/lib/presentation/components/search_filter_sheet.dart
@@ -1,0 +1,113 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_recipe/presentation/components/filter_buttons.dart';
+import 'package:flutter_recipe/presentation/components/small_button.dart';
+import 'package:flutter_recipe/presentation/filter/filter_state.dart';
+import 'package:flutter_recipe/ui/text_styles.dart';
+
+class SearchFilterSheet extends StatefulWidget {
+  final FilterState state;
+  final void Function(FilterState state) onChangeFilter;
+
+  const SearchFilterSheet({
+    super.key,
+    required this.state,
+    required this.onChangeFilter,
+  });
+
+  @override
+  State<SearchFilterSheet> createState() => _SearchFilterSheetState();
+}
+
+class _SearchFilterSheetState extends State<SearchFilterSheet> {
+  late FilterState _state;
+
+  @override
+  void initState() {
+    super.initState();
+    _state = widget.state;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 30),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const SizedBox(height: 31),
+          const SizedBox(
+            width: double.infinity,
+            child: Text(
+              'Filter Search',
+              style: TextStyles.smallTextBold,
+              textAlign: TextAlign.center,
+            ),
+          ),
+          const SizedBox(height: 20),
+          const Text('Time', style: TextStyles.smallTextBold),
+          const SizedBox(height: 10),
+          FilterButtons(
+            items: const ['All', 'Newest', 'Oldest', 'Popularity'],
+            selectedItem: _state.time,
+            onSelected: (String item) {
+              setState(() {
+                _state = _state.copyWith(time: item);
+              });
+            },
+          ),
+          const SizedBox(height: 20),
+          const Text('Rate', style: TextStyles.smallTextBold),
+          const SizedBox(height: 10),
+          FilterButtons(
+            items: const ['5', '4', '3', '2', '1'],
+            selectedItem: _state.rate.toString(),
+            onSelected: (String item) {
+              setState(() {
+                _state = _state.copyWith(rate: int.parse(item));
+              });
+            },
+          ),
+          const SizedBox(height: 20),
+          const Text('Category', style: TextStyles.smallTextBold),
+          const SizedBox(height: 10),
+          FilterButtons(
+            items: const [
+              'All',
+              'Cereal',
+              'Vegetables',
+              'Dinner',
+              'Chinese',
+              'Local Dish',
+              'Fruit',
+              'BreadFast',
+              'Spanish',
+              'Lunch',
+            ],
+            selectedItem: _state.category,
+            onSelected: (String item) {
+              setState(() {
+                _state = _state.copyWith(category: item);
+              });
+            },
+          ),
+          const SizedBox(height: 30),
+          Row(
+            children: [
+              const Spacer(),
+              SizedBox(
+                width: 174,
+                child: SmallButton(
+                  'Filter',
+                  onPressed: () => widget.onChangeFilter(_state),
+                ),
+              ),
+              const Spacer(),
+            ],
+          ),
+          const SizedBox(height: 22),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/presentation/components/search_filter_sheet.dart
+++ b/lib/presentation/components/search_filter_sheet.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_recipe/presentation/search/filter_state.dart';
 import 'package:flutter_recipe/presentation/components/filter_buttons.dart';
 import 'package:flutter_recipe/presentation/components/small_button.dart';
-import 'package:flutter_recipe/presentation/filter/filter_state.dart';
 import 'package:flutter_recipe/ui/text_styles.dart';
 
 class SearchFilterSheet extends StatefulWidget {

--- a/lib/presentation/search/filter_state.dart
+++ b/lib/presentation/search/filter_state.dart
@@ -1,0 +1,23 @@
+class FilterState {
+  final String time;
+  final int rate;
+  final String category;
+
+  const FilterState({
+    required this.time,
+    required this.rate,
+    required this.category,
+  });
+
+  FilterState copyWith({
+    String? time,
+    int? rate,
+    String? category,
+  }) {
+    return FilterState(
+      time: time ?? this.time,
+      rate: rate ?? this.rate,
+      category: category ?? this.category,
+    );
+  }
+}

--- a/lib/presentation/search/screen/search_root.dart
+++ b/lib/presentation/search/screen/search_root.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_recipe/core/di/di_setup.dart';
+import 'package:flutter_recipe/presentation/components/search_filter_sheet.dart';
+import 'package:flutter_recipe/presentation/filter/filter_state.dart';
 import 'package:flutter_recipe/presentation/search/screen/search_screen.dart';
 import 'package:flutter_recipe/presentation/search/search_view_model.dart';
 
@@ -16,6 +18,21 @@ class SearchRoot extends StatelessWidget {
         return SearchScreen(
           state: viewModel.state,
           onChanged: viewModel.searchRecipes,
+          onTapFilter: () {
+            showModalBottomSheet(
+              context: context,
+              isScrollControlled: true,
+              builder: (context) {
+                return SearchFilterSheet(
+                  state: viewModel.state.filterState,
+                  onChangeFilter: (FilterState state) {
+                    viewModel.onChangeFilter(state);
+                    Navigator.pop(context);
+                  },
+                );
+              },
+            );
+          },
         );
       },
     );

--- a/lib/presentation/search/screen/search_root.dart
+++ b/lib/presentation/search/screen/search_root.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_recipe/core/di/di_setup.dart';
+import 'package:flutter_recipe/presentation/search/filter_state.dart';
 import 'package:flutter_recipe/presentation/components/search_filter_sheet.dart';
-import 'package:flutter_recipe/presentation/filter/filter_state.dart';
 import 'package:flutter_recipe/presentation/search/screen/search_screen.dart';
 import 'package:flutter_recipe/presentation/search/search_view_model.dart';
 

--- a/lib/presentation/search/screen/search_screen.dart
+++ b/lib/presentation/search/screen/search_screen.dart
@@ -8,11 +8,13 @@ import 'package:flutter_recipe/ui/text_styles.dart';
 class SearchScreen extends StatelessWidget {
   final SearchState state;
   final void Function(String query)? onChanged;
+  final void Function()? onTapFilter;
 
   const SearchScreen({
     super.key,
     required this.state,
     this.onChanged,
+    this.onTapFilter,
   });
 
   @override
@@ -40,43 +42,57 @@ class SearchScreen extends StatelessWidget {
                   ),
                 ),
                 const SizedBox(width: 20),
-                Container(
-                  width: 40,
-                  height: 40,
-                  decoration: BoxDecoration(
-                    borderRadius: BorderRadius.circular(10),
-                    color: ColorStyles.primary100,
-                  ),
-                  child: const Icon(
-                    Icons.tune,
-                    color: Colors.white,
+                GestureDetector(
+                  onTap: onTapFilter,
+                  child: Container(
+                    width: 40,
+                    height: 40,
+                    decoration: BoxDecoration(
+                      borderRadius: BorderRadius.circular(10),
+                      color: ColorStyles.primary100,
+                    ),
+                    child: const Icon(
+                      Icons.tune,
+                      color: Colors.white,
+                    ),
                   ),
                 ),
               ],
             ),
             const SizedBox(height: 20),
-            const Text(
-              'Recent Search',
-              style: TextStyles.normalTextBold,
+            Row(
+              children: [
+                Text(
+                  state.searchTitle,
+                  style: TextStyles.normalTextBold,
+                ),
+                const Spacer(),
+                Text(
+                  state.resultsCount,
+                  style: TextStyles.smallerTextRegular.copyWith(
+                    color: ColorStyles.gray3,
+                  ),
+                ),
+              ],
             ),
             const SizedBox(height: 20),
             Expanded(
               child: state.isLoading
                   ? const Center(
-                      child: CircularProgressIndicator(),
-                    )
+                child: CircularProgressIndicator(),
+              )
                   : GridView.builder(
-                      gridDelegate:
-                          const SliverGridDelegateWithFixedCrossAxisCount(
-                        crossAxisCount: 2,
-                        crossAxisSpacing: 15,
-                      ),
-                      itemCount: state.recipes.length,
-                      itemBuilder: (context, index) {
-                        final recipe = state.recipes[index];
-                        return RecipeGridItem(recipe: recipe);
-                      },
-                    ),
+                gridDelegate:
+                const SliverGridDelegateWithFixedCrossAxisCount(
+                  crossAxisCount: 2,
+                  crossAxisSpacing: 15,
+                ),
+                itemCount: state.recipes.length,
+                itemBuilder: (context, index) {
+                  final recipe = state.recipes[index];
+                  return RecipeGridItem(recipe: recipe);
+                },
+              ),
             )
           ],
         ),

--- a/lib/presentation/search/search_state.dart
+++ b/lib/presentation/search/search_state.dart
@@ -1,5 +1,5 @@
+import 'package:flutter_recipe/presentation/search/filter_state.dart';
 import 'package:flutter_recipe/domain/model/recipe.dart';
-import 'package:flutter_recipe/presentation/filter/filter_state.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'search_state.freezed.dart';

--- a/lib/presentation/search/search_state.dart
+++ b/lib/presentation/search/search_state.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_recipe/domain/model/recipe.dart';
+import 'package:flutter_recipe/presentation/filter/filter_state.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'search_state.freezed.dart';
@@ -8,5 +9,10 @@ class SearchState with _$SearchState {
   const factory SearchState({
     @Default([]) List<Recipe> recipes,
     @Default(false) bool isLoading,
+    @Default('Recent Search') String searchTitle,
+    @Default('') String resultsCount,
+    @Default(FilterState(time: 'All', rate: 1, category: 'All'))
+    FilterState filterState,
+    @Default('') String query,
   }) = _SearchState;
 }

--- a/lib/presentation/search/search_view_model.dart
+++ b/lib/presentation/search/search_view_model.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_recipe/presentation/search/filter_state.dart';
 import 'package:flutter_recipe/domain/repository/recent_search_recipe_repository.dart';
 import 'package:flutter_recipe/domain/use_case/search_recipes_use_case.dart';
-import 'package:flutter_recipe/presentation/filter/filter_state.dart';
 import 'package:flutter_recipe/presentation/search/search_state.dart';
 
 class SearchViewModel with ChangeNotifier {

--- a/lib/presentation/search/search_view_model.dart
+++ b/lib/presentation/search/search_view_model.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_recipe/domain/repository/recent_search_recipe_repository.dart';
 import 'package:flutter_recipe/domain/use_case/search_recipes_use_case.dart';
+import 'package:flutter_recipe/presentation/filter/filter_state.dart';
 import 'package:flutter_recipe/presentation/search/search_state.dart';
 
 class SearchViewModel with ChangeNotifier {
@@ -48,5 +49,12 @@ class SearchViewModel with ChangeNotifier {
       isLoading: false,
     );
     notifyListeners();
+  }
+
+  void onChangeFilter(FilterState filterState) async {
+    _state = state.copyWith(filterState: filterState);
+    notifyListeners();
+
+    print(state.toString());
   }
 }


### PR DESCRIPTION
## 📝 작업 내용
- FilterState 정의 후 presentation 계층으로 이동
- FilterButtons 컴포넌트 구현
- SearchFilterSheet (ModalBottomSheet) 구현
- SearchScreen과 SearchRoot에 필터 기능 연동
- SearchViewModel에 필터 상태 관리 추가

## 💡 변경 사항
1. **FilterState 위치 변경**: domain/model → presentation/search
  - UI 상태 관리에 더 적합한 위치로 이동
  - 필터 관련 컴포넌트들과 같은 계층에 배치

2. **컴포넌트 구현**
  - FilterButtons: 필터 선택 버튼 구현
  - SearchFilterSheet: 하단 시트 형태의 필터 UI 구현
  - 컴포넌트 간 상태 연동 처리

3. **상태 관리**
  - SearchState에 필터 상태 추가
  - SearchViewModel에서 필터 변경 처리 구현