### PR TITLE
[FEAT/#78] Home 카테고리 셀렉터 및 데이터 연동

### DIFF
--- a/lib/core/di/di_setup.dart
+++ b/lib/core/di/di_setup.dart
@@ -8,8 +8,10 @@ import 'package:flutter_recipe/data/repository/recent_search_recipe_repository_i
 import 'package:flutter_recipe/domain/repository/bookmark_repository.dart';
 import 'package:flutter_recipe/domain/repository/recent_search_recipe_repository.dart';
 import 'package:flutter_recipe/domain/repository/recipe_repository.dart';
+import 'package:flutter_recipe/domain/use_case/get_categories_use_case.dart';
 import 'package:flutter_recipe/domain/use_case/get_saved_recipes_use_case.dart';
 import 'package:flutter_recipe/domain/use_case/search_recipes_use_case.dart';
+import 'package:flutter_recipe/presentation/home/home_view_model.dart';
 import 'package:flutter_recipe/presentation/saved_recipes/saved_recipes_view_model.dart';
 import 'package:flutter_recipe/presentation/search/search_view_model.dart';
 import 'package:get_it/get_it.dart';
@@ -54,6 +56,12 @@ void diSetup() {
     ),
   );
 
+  getIt.registerSingleton(
+    GetCategoriesUseCase(
+      recipeRepository: getIt(),
+    ),
+  );
+
   // ViewModel은 상태를 유지하거나 변경하는 객체이기 때문에 각 화면마다 별개의 인스턴스를 생성해야 하기에 Factory로
   // ViewModel을 요청할 때마다 새로운 인스턴스를 생성하고, ViewModel이 필요로 하는 의존성(UseCase)을 GetIt에서 가져와서 주입
   getIt.registerFactory<SavedRecipesViewModel>(
@@ -66,6 +74,12 @@ void diSetup() {
     () => SearchViewModel(
       recentSearchRecipeRepository: getIt(),
       searchRecipesUseCase: getIt(),
+    ),
+  );
+
+  getIt.registerFactory<HomeViewModel>(
+        () => HomeViewModel(
+      getCategoriesUseCase: getIt(),
     ),
   );
 }

--- a/lib/domain/use_case/get_categories_use_case.dart
+++ b/lib/domain/use_case/get_categories_use_case.dart
@@ -1,0 +1,17 @@
+import 'package:flutter_recipe/domain/repository/recipe_repository.dart';
+
+class GetCategoriesUseCase {
+  final RecipeRepository _recipeRepository;
+
+  const GetCategoriesUseCase({
+    required RecipeRepository recipeRepository,
+  }) : _recipeRepository = recipeRepository;
+
+  Future<List<String>> execute() async {
+    final recipes = await _recipeRepository.getRecipes();
+    return [
+      'All',
+      ...recipes.map((e) => e.category).toSet(),
+    ];
+  }
+}

--- a/lib/presentation/components/recipe_category_selector.dart
+++ b/lib/presentation/components/recipe_category_selector.dart
@@ -1,0 +1,85 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_recipe/ui/color_styles.dart';
+import 'package:flutter_recipe/ui/text_styles.dart';
+
+class RecipeCategorySelector extends StatelessWidget {
+  final List<String> categories;
+  final String selectedCategory;
+  final void Function(String category) onSelectCategory;
+
+  const RecipeCategorySelector({
+    super.key,
+    required this.categories,
+    required this.onSelectCategory,
+    required this.selectedCategory,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      scrollDirection: Axis.horizontal,
+      child: Row(
+        children: categories.map((e) {
+          return GestureDetector(
+            behavior: HitTestBehavior.opaque,
+            onTap: () => onSelectCategory(e),
+            child: e == selectedCategory
+                ? SelectedCategory(category: e)
+                : UnSelectedCategory(category: e),
+          );
+        }).toList(),
+      ),
+    );
+  }
+}
+
+class UnSelectedCategory extends StatelessWidget {
+  final String category;
+
+  const UnSelectedCategory({
+    super.key,
+    required this.category,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 7),
+      child: Text(
+        category,
+        style: TextStyles.smallerTextBold.copyWith(
+          color: ColorStyles.primary80,
+        ),
+      ),
+    );
+  }
+}
+
+class SelectedCategory extends StatelessWidget {
+  final String category;
+
+  const SelectedCategory({
+    super.key,
+    required this.category,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(10),
+        color: ColorStyles.primary100,
+      ),
+      padding: const EdgeInsets.symmetric(
+        horizontal: 20,
+        vertical: 7,
+      ),
+      child: Text(
+        category,
+        style: TextStyles.smallerTextBold.copyWith(
+          color: Colors.white,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/home/home_state.dart
+++ b/lib/presentation/home/home_state.dart
@@ -6,7 +6,7 @@ part 'home_state.freezed.dart';
 @freezed
 class HomeState with _$HomeState {
   const factory HomeState({
-    @Default([]) List<Recipe> recipes,
-    @Default(false) bool isLoading,
+    @Default([]) List<String> categories,
+    @Default('All') String selectedCategory,
   }) = _HomeState;
 }

--- a/lib/presentation/home/home_view_model.dart
+++ b/lib/presentation/home/home_view_model.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_recipe/domain/use_case/get_categories_use_case.dart';
+
+import 'home_state.dart';
+
+class HomeViewModel with ChangeNotifier {
+  final GetCategoriesUseCase _getCategoriesUseCase;
+
+  HomeViewModel({
+    required GetCategoriesUseCase getCategoriesUseCase,
+  }) : _getCategoriesUseCase = getCategoriesUseCase {
+    _fetchCategories();
+  }
+
+  HomeState _state = const HomeState();
+
+  HomeState get state => _state;
+
+  void _fetchCategories() async {
+    _state = state.copyWith(
+      categories: await _getCategoriesUseCase.execute(),
+      selectedCategory: 'All',
+    );
+    notifyListeners();
+  }
+
+  void onSelectCategory(String category) async {
+    _state = state.copyWith(selectedCategory: category);
+    notifyListeners();
+  }
+}

--- a/lib/presentation/home/screen/home_root.dart
+++ b/lib/presentation/home/screen/home_root.dart
@@ -1,17 +1,26 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_recipe/core/di/di_setup.dart';
 import 'package:flutter_recipe/core/routing/route_paths.dart';
+import 'package:flutter_recipe/presentation/home/home_view_model.dart';
 import 'package:flutter_recipe/presentation/home/screen/home_screen.dart';
 import 'package:go_router/go_router.dart';
-
 
 class HomeRoot extends StatelessWidget {
   const HomeRoot({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return HomeScreen(
-      name: 'Jega',
-      onTapSearchField: () => context.push(RoutePaths.search),
+    final viewModel = getIt<HomeViewModel>();
+    return ListenableBuilder(
+      builder: (context, widget) {
+        return HomeScreen(
+          state: viewModel.state,
+          name: 'Jega',
+          onTapSearchField: () => context.push(RoutePaths.search),
+          onSelectCategory: viewModel.onSelectCategory,
+        );
+      },
+      listenable: viewModel,
     );
   }
 }

--- a/lib/presentation/home/screen/home_screen.dart
+++ b/lib/presentation/home/screen/home_screen.dart
@@ -1,88 +1,111 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_recipe/presentation/components/recipe_category_selector.dart';
 import 'package:flutter_recipe/presentation/components/search_input_field.dart';
+import 'package:flutter_recipe/presentation/home/home_state.dart';
 import 'package:flutter_recipe/ui/color_styles.dart';
 import 'package:flutter_recipe/ui/text_styles.dart';
 
 class HomeScreen extends StatelessWidget {
   final String name;
   final void Function() onTapSearchField;
+  final void Function(String category) onSelectCategory;
+  final HomeState state;
 
   const HomeScreen({
     super.key,
     required this.name,
     required this.onTapSearchField,
+    required this.state,
+    required this.onSelectCategory,
   });
 
   @override
   Widget build(BuildContext context) {
     return SafeArea(
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 30),
-        child: Column(
-          children: [
-            const SizedBox(height: 20),
-            Row(
+      child: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 30),
+            child: Column(
               children: [
-                Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
+                const SizedBox(height: 20),
+                Row(
                   children: [
-                    Text(
-                      'Hello $name',
-                      style: TextStyles.largeTextBold,
+                    Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          'Hello $name',
+                          style: TextStyles.largeTextBold,
+                        ),
+                        const SizedBox(height: 5),
+                        Text(
+                          'What are you cooking today?',
+                          style: TextStyles.smallerTextRegular.copyWith(
+                            color: ColorStyles.gray3,
+                          ),
+                        )
+                      ],
                     ),
-                    const SizedBox(height: 5),
-                    Text(
-                      'What are you cooking today?',
-                      style: TextStyles.smallerTextRegular.copyWith(
-                        color: ColorStyles.gray3,
+                    const Spacer(),
+                    Container(
+                      width: 40,
+                      height: 40,
+                      decoration: BoxDecoration(
+                        borderRadius: BorderRadius.circular(10),
+                        color: ColorStyles.secondary40,
                       ),
-                    )
+                      child: Image.asset('assets/image/face.png'),
+                    ),
                   ],
                 ),
-                const Spacer(),
-                Container(
-                  width: 40,
-                  height: 40,
-                  decoration: BoxDecoration(
-                    borderRadius: BorderRadius.circular(10),
-                    color: ColorStyles.secondary40,
-                  ),
-                  child: Image.asset('assets/image/face.png'),
-                ),
-              ],
-            ),
-            const SizedBox(height: 30),
-            Row(
-              children: [
-                Expanded(
-                  child: GestureDetector(
-                    behavior: HitTestBehavior.opaque,
-                    onTap: onTapSearchField,
-                    child: const IgnorePointer(
-                      child: SearchInputField(
-                        placeHolder: 'Search Recipe',
-                        isReadOnly: true,
+                const SizedBox(height: 30),
+                Row(
+                  children: [
+                    Expanded(
+                      child: GestureDetector(
+                        behavior: HitTestBehavior.opaque,
+                        onTap: onTapSearchField,
+                        child: const IgnorePointer(
+                          child: SearchInputField(
+                            placeHolder: 'Search Recipe',
+                            isReadOnly: true,
+                          ),
+                        ),
                       ),
                     ),
-                  ),
-                ),
-                const SizedBox(width: 20),
-                Container(
-                  width: 40,
-                  height: 40,
-                  decoration: BoxDecoration(
-                    borderRadius: BorderRadius.circular(10),
-                    color: ColorStyles.primary100,
-                  ),
-                  child: const Icon(
-                    Icons.tune,
-                    color: Colors.white,
-                  ),
+                    const SizedBox(width: 20),
+                    Container(
+                      width: 40,
+                      height: 40,
+                      decoration: BoxDecoration(
+                        borderRadius: BorderRadius.circular(10),
+                        color: ColorStyles.primary100,
+                      ),
+                      child: const Icon(
+                        Icons.tune,
+                        color: Colors.white,
+                      ),
+                    ),
+                  ],
                 ),
               ],
             ),
-          ],
-        ),
+          ),
+          const SizedBox(height: 15),
+          Padding(
+            padding: const EdgeInsets.only(
+              left: 30,
+              top: 10,
+              bottom: 10,
+            ),
+            child: RecipeCategorySelector(
+              categories: state.categories,
+              selectedCategory: state.selectedCategory,
+              onSelectCategory: onSelectCategory,
+            ),
+          ),
+        ],
       ),
     );
   }


### PR DESCRIPTION
## 📝 작업 내용
- 홈 화면에 가로 스크롤 가능한 카테고리 셀렉터 구현
- 카테고리 데이터 처리를 위한 UseCase 구현
- 카테고리 상태 관리 및 UI 연동

## 💡 변경 사항

1. 카테고리 데이터 처리
  - GetCategoriesUseCase 구현
  - 레시피 데이터에서 유니크한 카테고리 목록 추출

2. UI 컴포넌트
  - RecipeCategorySelector 컴포넌트 구현
  - 선택/미선택 상태에 따른 카테고리 버튼 디자인
  - 가로 스크롤 지원

3. 상태 관리
  - HomeState에 카테고리 관련 상태 추가
  - HomeViewModel을 통한 카테고리 데이터 로드 및 선택 처리
  - DI 설정 추가