### PR TITLE
[FEAT/#80] Dishes 영역 추가 및 카테고리 필터링 구현

### DIFF
--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.1.0" apply false
+    id "com.android.application" version "8.2.1" apply false
     id "org.jetbrains.kotlin.android" version "1.8.22" apply false
 }
 

--- a/lib/core/di/di_setup.dart
+++ b/lib/core/di/di_setup.dart
@@ -9,6 +9,7 @@ import 'package:flutter_recipe/domain/repository/bookmark_repository.dart';
 import 'package:flutter_recipe/domain/repository/recent_search_recipe_repository.dart';
 import 'package:flutter_recipe/domain/repository/recipe_repository.dart';
 import 'package:flutter_recipe/domain/use_case/get_categories_use_case.dart';
+import 'package:flutter_recipe/domain/use_case/get_dishes_by_category_use_case.dart';
 import 'package:flutter_recipe/domain/use_case/get_saved_recipes_use_case.dart';
 import 'package:flutter_recipe/domain/use_case/search_recipes_use_case.dart';
 import 'package:flutter_recipe/presentation/home/home_view_model.dart';
@@ -62,6 +63,12 @@ void diSetup() {
     ),
   );
 
+  getIt.registerSingleton(
+    GetDishesByCategoryUseCase(
+      recipeRepository: getIt(),
+    ),
+  );
+
   // ViewModel은 상태를 유지하거나 변경하는 객체이기 때문에 각 화면마다 별개의 인스턴스를 생성해야 하기에 Factory로
   // ViewModel을 요청할 때마다 새로운 인스턴스를 생성하고, ViewModel이 필요로 하는 의존성(UseCase)을 GetIt에서 가져와서 주입
   getIt.registerFactory<SavedRecipesViewModel>(
@@ -78,8 +85,9 @@ void diSetup() {
   );
 
   getIt.registerFactory<HomeViewModel>(
-        () => HomeViewModel(
+    () => HomeViewModel(
       getCategoriesUseCase: getIt(),
+      getDishesByCategoryUseCase: getIt(),
     ),
   );
 }

--- a/lib/domain/use_case/get_dishes_by_category_use_case.dart
+++ b/lib/domain/use_case/get_dishes_by_category_use_case.dart
@@ -1,0 +1,20 @@
+import 'package:flutter_recipe/domain/model/recipe.dart';
+import 'package:flutter_recipe/domain/repository/recipe_repository.dart';
+
+class GetDishesByCategoryUseCase {
+  final RecipeRepository _recipeRepository;
+
+  const GetDishesByCategoryUseCase({
+    required RecipeRepository recipeRepository,
+  }) : _recipeRepository = recipeRepository;
+
+  Future<List<Recipe>> execute(String category) async {
+    final recipes = await _recipeRepository.getRecipes();
+
+    if (category == 'All') {
+      return recipes;
+    }
+
+    return recipes.where((e) => e.category == category).toList();
+  }
+}

--- a/lib/presentation/components/dish_card.dart
+++ b/lib/presentation/components/dish_card.dart
@@ -1,0 +1,130 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_recipe/domain/model/recipe.dart';
+import 'package:flutter_recipe/ui/color_styles.dart';
+import 'package:flutter_recipe/ui/text_styles.dart';
+
+class DishCard extends StatelessWidget {
+  final Recipe recipe;
+  final bool isFavorite;
+
+  const DishCard({
+    super.key,
+    required this.recipe,
+    required this.isFavorite,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: 150,
+      height: 230,
+      child: Stack(
+        children: [
+          Positioned(
+            bottom: 0,
+            child: Container(
+              width: 150,
+              height: 176,
+              padding: const EdgeInsets.only(top: 24),  // 상단 패딩 추가
+              decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(12),
+                color: ColorStyles.gray4,
+              ),
+              child: Center(
+                child: SizedBox(
+                  width: 130,
+                  height: 48,
+                  child: Text(
+                    recipe.name,
+                    style: TextStyles.smallTextBold,
+                    textAlign: TextAlign.center,
+                    maxLines: 3,  // 2줄까지 표시
+                    overflow: TextOverflow.ellipsis,  // 초과시 ... 표시
+                  ),
+                ),
+              ),
+            ),
+          ),
+          Positioned(
+            left: 10,
+            bottom: 10,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Time',
+                  style: TextStyles.smallerTextRegular.copyWith(
+                    color: ColorStyles.gray3,
+                  ),
+                ),
+                const SizedBox(height: 5),
+                Text(
+                  recipe.time,
+                  style: TextStyles.smallerTextBold.copyWith(
+                    color: ColorStyles.gray1,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          Positioned(
+            right: 10,
+            bottom: 10,
+            child: Container(
+              width: 24,
+              height: 24,
+              decoration: const BoxDecoration(
+                color: Colors.white,
+                shape: BoxShape.circle,
+              ),
+              child: Icon(
+                Icons.bookmark_outline,
+                color: isFavorite ? ColorStyles.primary80 : ColorStyles.gray3,
+                size: 16,
+              ),
+            ),
+          ),
+          Positioned(
+            left: 0,
+            right: 0,
+            child: SizedBox(
+              width: 110,
+              height: 110,
+              child: CircleAvatar(
+                backgroundImage: NetworkImage(
+                  recipe.image,
+                ),
+              ),
+            ),
+          ),
+          Positioned(
+            top: 30,
+            right: 0,
+            child: Container(
+              width: 45,
+              height: 23,
+              decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(20),
+                color: ColorStyles.secondary20,
+              ),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  const Icon(
+                    Icons.star,
+                    color: ColorStyles.rating,
+                    size: 10,
+                  ),
+                  Text(
+                    recipe.rating.toString(),
+                    style: TextStyles.smallerTextRegular,
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/presentation/components/recipe_grid_item.dart
+++ b/lib/presentation/components/recipe_grid_item.dart
@@ -29,17 +29,15 @@ class RecipeGridItem extends StatelessWidget {
           Positioned(
             bottom: 10,
             left: 10,
+            right: 10,
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                SizedBox(
-                  width: 200,
-                  child: Text(
-                    recipe.name,
-                    maxLines: 2,
-                    style: TextStyles.smallTextBold.copyWith(
-                      color: Colors.white,
-                    ),
+                Text(
+                  recipe.name,
+                  maxLines: 2,
+                  style: TextStyles.smallTextBold.copyWith(
+                    color: Colors.white,
                   ),
                 ),
                 Text(

--- a/lib/presentation/home/home_state.dart
+++ b/lib/presentation/home/home_state.dart
@@ -8,5 +8,6 @@ class HomeState with _$HomeState {
   const factory HomeState({
     @Default([]) List<String> categories,
     @Default('All') String selectedCategory,
+    @Default([]) List<Recipe> dishes,
   }) = _HomeState;
 }

--- a/lib/presentation/home/home_view_model.dart
+++ b/lib/presentation/home/home_view_model.dart
@@ -1,14 +1,18 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_recipe/domain/use_case/get_categories_use_case.dart';
+import 'package:flutter_recipe/domain/use_case/get_dishes_by_category_use_case.dart';
 
 import 'home_state.dart';
 
 class HomeViewModel with ChangeNotifier {
   final GetCategoriesUseCase _getCategoriesUseCase;
+  final GetDishesByCategoryUseCase _getDishesByCategoryUseCase;
 
   HomeViewModel({
     required GetCategoriesUseCase getCategoriesUseCase,
-  }) : _getCategoriesUseCase = getCategoriesUseCase {
+    required GetDishesByCategoryUseCase getDishesByCategoryUseCase,
+  })  : _getCategoriesUseCase = getCategoriesUseCase,
+        _getDishesByCategoryUseCase = getDishesByCategoryUseCase {
     _fetchCategories();
   }
 
@@ -22,10 +26,21 @@ class HomeViewModel with ChangeNotifier {
       selectedCategory: 'All',
     );
     notifyListeners();
+
+    await _fetchDishesByCategory('All');
+    notifyListeners();
+  }
+
+  Future<void> _fetchDishesByCategory(String category) async {
+    final dishes = await _getDishesByCategoryUseCase.execute(category);
+    _state = state.copyWith(dishes: dishes);
+    notifyListeners();
   }
 
   void onSelectCategory(String category) async {
     _state = state.copyWith(selectedCategory: category);
     notifyListeners();
+
+    await _fetchDishesByCategory(category);
   }
 }

--- a/lib/presentation/home/screen/home_screen.dart
+++ b/lib/presentation/home/screen/home_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_recipe/presentation/components/dish_card.dart';
 import 'package:flutter_recipe/presentation/components/recipe_category_selector.dart';
 import 'package:flutter_recipe/presentation/components/search_input_field.dart';
 import 'package:flutter_recipe/presentation/home/home_state.dart';
@@ -22,90 +23,117 @@ class HomeScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return SafeArea(
-      child: Column(
-        children: [
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 30),
-            child: Column(
-              children: [
-                const SizedBox(height: 20),
-                Row(
-                  children: [
-                    Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          'Hello $name',
-                          style: TextStyles.largeTextBold,
-                        ),
-                        const SizedBox(height: 5),
-                        Text(
-                          'What are you cooking today?',
-                          style: TextStyles.smallerTextRegular.copyWith(
-                            color: ColorStyles.gray3,
+      child: SingleChildScrollView(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 30),
+              child: Column(
+                children: [
+                  const SizedBox(height: 20),
+                  Row(
+                    children: [
+                      Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            'Hello $name',
+                            style: TextStyles.largeTextBold,
                           ),
-                        )
-                      ],
-                    ),
-                    const Spacer(),
-                    Container(
-                      width: 40,
-                      height: 40,
-                      decoration: BoxDecoration(
-                        borderRadius: BorderRadius.circular(10),
-                        color: ColorStyles.secondary40,
+                          const SizedBox(height: 5),
+                          Text(
+                            'What are you cooking today?',
+                            style: TextStyles.smallerTextRegular.copyWith(
+                              color: ColorStyles.gray3,
+                            ),
+                          )
+                        ],
                       ),
-                      child: Image.asset('assets/image/face.png'),
-                    ),
-                  ],
-                ),
-                const SizedBox(height: 30),
-                Row(
-                  children: [
-                    Expanded(
-                      child: GestureDetector(
-                        behavior: HitTestBehavior.opaque,
-                        onTap: onTapSearchField,
-                        child: const IgnorePointer(
-                          child: SearchInputField(
-                            placeHolder: 'Search Recipe',
-                            isReadOnly: true,
+                      const Spacer(),
+                      Container(
+                        width: 40,
+                        height: 40,
+                        decoration: BoxDecoration(
+                          borderRadius: BorderRadius.circular(10),
+                          color: ColorStyles.secondary40,
+                        ),
+                        child: Image.asset('assets/image/face.png'),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 30),
+                  Row(
+                    children: [
+                      Expanded(
+                        child: GestureDetector(
+                          behavior: HitTestBehavior.opaque,
+                          onTap: onTapSearchField,
+                          child: const IgnorePointer(
+                            child: SearchInputField(
+                              placeHolder: 'Search Recipe',
+                              isReadOnly: true,
+                            ),
                           ),
                         ),
                       ),
-                    ),
-                    const SizedBox(width: 20),
-                    Container(
-                      width: 40,
-                      height: 40,
-                      decoration: BoxDecoration(
-                        borderRadius: BorderRadius.circular(10),
-                        color: ColorStyles.primary100,
+                      const SizedBox(width: 20),
+                      Container(
+                        width: 40,
+                        height: 40,
+                        decoration: BoxDecoration(
+                          borderRadius: BorderRadius.circular(10),
+                          color: ColorStyles.primary100,
+                        ),
+                        child: const Icon(
+                          Icons.tune,
+                          color: Colors.white,
+                        ),
                       ),
-                      child: const Icon(
-                        Icons.tune,
-                        color: Colors.white,
-                      ),
-                    ),
-                  ],
+                    ],
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 15),
+            SizedBox(
+              height: 50,
+              child: SingleChildScrollView(
+                scrollDirection: Axis.horizontal,
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 30),
+                  child: RecipeCategorySelector(
+                    categories: state.categories,
+                    selectedCategory: state.selectedCategory,
+                    onSelectCategory: onSelectCategory,
+                  ),
                 ),
-              ],
+              ),
             ),
-          ),
-          const SizedBox(height: 15),
-          Padding(
-            padding: const EdgeInsets.only(
-              left: 30,
-              top: 10,
-              bottom: 10,
+            const SizedBox(height: 15),
+            SizedBox(
+              height: 220,
+              child: SingleChildScrollView(
+                scrollDirection: Axis.horizontal,
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 30),
+                  child: Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: state.dishes
+                        .map((e) => Padding(
+                      padding: const EdgeInsets.only(right: 15),
+                      child: DishCard(
+                        recipe: e,
+                        isFavorite: true,
+                      ),
+                    ))
+                        .toList(),
+                  ),
+                ),
+              ),
             ),
-            child: RecipeCategorySelector(
-              categories: state.categories,
-              selectedCategory: state.selectedCategory,
-              onSelectCategory: onSelectCategory,
-            ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }

--- a/lib/presentation/sign_in/sign_in_screen.dart
+++ b/lib/presentation/sign_in/sign_in_screen.dart
@@ -18,103 +18,105 @@ class SignInScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       body: SafeArea(
-        child: Padding(
-          padding: const EdgeInsets.all(30.0),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              const SizedBox(height: 50),
-              const Text(
-                'Hello,',
-                style: TextStyles.headerTextBold,
-              ),
-              const Text(
-                'Welcome Back!',
-                style: TextStyles.largeTextRegular,
-              ),
-              const SizedBox(height: 57),
-              const InputField(
-                label: 'Email',
-                placeHolder: 'Enter Email',
-              ),
-              const SizedBox(height: 30),
-              const InputField(
-                label: 'Enter Password',
-                placeHolder: 'Enter Password',
-              ),
-              const SizedBox(height: 20),
-              Text(
-                'Forgot Password?',
-                style: TextStyles.smallerTextRegular.copyWith(
-                  color: ColorStyles.secondary100,
+        child: SingleChildScrollView(
+          child: Padding(
+            padding: const EdgeInsets.all(30.0),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const SizedBox(height: 50),
+                const Text(
+                  'Hello,',
+                  style: TextStyles.headerTextBold,
                 ),
-              ),
-              const SizedBox(height: 25),
-              BigButton(
-                'Sign In',
-                onPressed: onTapSignIn,
-              ),
-              const SizedBox(height: 20),
-              Row(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  Container(
-                    width: 50,
-                    height: 1,
-                    color: ColorStyles.gray4,
+                const Text(
+                  'Welcome Back!',
+                  style: TextStyles.largeTextRegular,
+                ),
+                const SizedBox(height: 57),
+                const InputField(
+                  label: 'Email',
+                  placeHolder: 'Enter Email',
+                ),
+                const SizedBox(height: 30),
+                const InputField(
+                  label: 'Enter Password',
+                  placeHolder: 'Enter Password',
+                ),
+                const SizedBox(height: 20),
+                Text(
+                  'Forgot Password?',
+                  style: TextStyles.smallerTextRegular.copyWith(
+                    color: ColorStyles.secondary100,
                   ),
-                  const SizedBox(width: 7),
-                  Text(
-                    'Or Sign in With',
-                    style: TextStyles.smallerTextBold.copyWith(
+                ),
+                const SizedBox(height: 25),
+                BigButton(
+                  'Sign In',
+                  onPressed: onTapSignIn,
+                ),
+                const SizedBox(height: 20),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Container(
+                      width: 50,
+                      height: 1,
                       color: ColorStyles.gray4,
                     ),
-                  ),
-                  const SizedBox(width: 7),
-                  Container(
-                    width: 50,
-                    height: 1,
-                    color: ColorStyles.gray4,
-                  ),
-                ],
-              ),
-              const SizedBox(height: 20),
-              Row(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  Image.asset(
-                    'assets/image/google_button.png',
-                    width: 60,
-                    height: 60,
-                  ),
-                  const SizedBox(width: 15),
-                  Image.asset(
-                    'assets/image/facebook_button.png',
-                    width: 60,
-                    height: 60,
-                  ),
-                ],
-              ),
-              const SizedBox(height: 55),
-              Row(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  const Text(
-                    'Don’t have an account? ',
-                    style: TextStyles.smallerTextBold,
-                  ),
-                  GestureDetector(
-                    onTap: onTapSignUp,
-                    child: Text(
-                      'Sign up',
+                    const SizedBox(width: 7),
+                    Text(
+                      'Or Sign in With',
                       style: TextStyles.smallerTextBold.copyWith(
-                        color: ColorStyles.secondary100,
+                        color: ColorStyles.gray4,
                       ),
                     ),
-                  ),
-                ],
-              ),
-            ],
+                    const SizedBox(width: 7),
+                    Container(
+                      width: 50,
+                      height: 1,
+                      color: ColorStyles.gray4,
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 20),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Image.asset(
+                      'assets/image/google_button.png',
+                      width: 60,
+                      height: 60,
+                    ),
+                    const SizedBox(width: 15),
+                    Image.asset(
+                      'assets/image/facebook_button.png',
+                      width: 60,
+                      height: 60,
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 55),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    const Text(
+                      'Don’t have an account? ',
+                      style: TextStyles.smallerTextBold,
+                    ),
+                    GestureDetector(
+                      onTap: onTapSignUp,
+                      child: Text(
+                        'Sign up',
+                        style: TextStyles.smallerTextBold.copyWith(
+                          color: ColorStyles.secondary100,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
           ),
         ),
       ),


### PR DESCRIPTION
## 📝 작업 내용

- HomeScreen에 Dishes 영역 추가
- 카테고리 선택에 따른 레시피 필터링 구현
- DishCard 컴포넌트 구현

## 💡 변경 사항

1. UseCase 구현

  - GetDishesByCategoryUseCase 추가
  - 카테고리별 레시피 필터링 로직 구현


2. UI 컴포넌트

  - DishCard 컴포넌트 구현
  - 레시피 이미지, 제목, 시간, 북마크 상태 표시
  - 가로 스크롤 가능한 레이아웃


3. 상태 관리

  - HomeState에 dishes 상태 추가
  - HomeViewModel에 카테고리 필터링 로직 구현
  - DI 설정 추가



🔧 기타 수정사항

- AGP 버전 8.2.1로 업데이트
- SignInScreen에 스크롤 기능 추가
- RecipeGridItem의 레시피 제목 너비 조정

Closes #80